### PR TITLE
[Phase 1] Board READ API の実装（GET /api/boards）

### DIFF
--- a/backend/src/main/java/com/taskmanagement/controller/BoardController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/BoardController.java
@@ -1,0 +1,27 @@
+package com.taskmanagement.controller;
+
+import com.taskmanagement.dto.BoardDetailResponse;
+import com.taskmanagement.dto.BoardSummaryResponse;
+import com.taskmanagement.service.BoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/boards")
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final BoardService boardService;
+
+    @GetMapping
+    public List<BoardSummaryResponse> getBoards() {
+        return boardService.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public BoardDetailResponse getBoard(@PathVariable Long id) {
+        return boardService.findById(id);
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/controller/BoardListController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/BoardListController.java
@@ -1,0 +1,37 @@
+package com.taskmanagement.controller;
+
+import com.taskmanagement.dto.CreateListRequest;
+import com.taskmanagement.dto.ListResponse;
+import com.taskmanagement.dto.UpdateListRequest;
+import com.taskmanagement.service.BoardListService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class BoardListController {
+
+    private final BoardListService boardListService;
+
+    @PostMapping("/boards/{boardId}/lists")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ListResponse createList(@PathVariable Long boardId,
+                                   @RequestBody @Valid CreateListRequest req) {
+        return boardListService.create(boardId, req);
+    }
+
+    @PatchMapping("/lists/{id}")
+    public ListResponse updateList(@PathVariable Long id,
+                                   @RequestBody UpdateListRequest req) {
+        return boardListService.update(id, req);
+    }
+
+    @DeleteMapping("/lists/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteList(@PathVariable Long id) {
+        boardListService.delete(id);
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/controller/CardController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/CardController.java
@@ -1,0 +1,37 @@
+package com.taskmanagement.controller;
+
+import com.taskmanagement.dto.CardResponse;
+import com.taskmanagement.dto.CreateCardRequest;
+import com.taskmanagement.dto.UpdateCardRequest;
+import com.taskmanagement.service.CardService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CardController {
+
+    private final CardService cardService;
+
+    @PostMapping("/lists/{listId}/cards")
+    @ResponseStatus(HttpStatus.CREATED)
+    public CardResponse createCard(@PathVariable Long listId,
+                                   @RequestBody @Valid CreateCardRequest req) {
+        return cardService.create(listId, req);
+    }
+
+    @PatchMapping("/cards/{id}")
+    public CardResponse updateCard(@PathVariable Long id,
+                                   @RequestBody UpdateCardRequest req) {
+        return cardService.update(id, req);
+    }
+
+    @DeleteMapping("/cards/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteCard(@PathVariable Long id) {
+        cardService.delete(id);
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/controller/LabelController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/LabelController.java
@@ -1,0 +1,34 @@
+package com.taskmanagement.controller;
+
+import com.taskmanagement.dto.LabelResponse;
+import com.taskmanagement.service.LabelService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class LabelController {
+
+    private final LabelService labelService;
+
+    @GetMapping("/labels")
+    public List<LabelResponse> getLabels() {
+        return labelService.findAll();
+    }
+
+    @PostMapping("/cards/{cardId}/labels/{labelId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void attachLabel(@PathVariable Long cardId, @PathVariable Long labelId) {
+        labelService.attach(cardId, labelId);
+    }
+
+    @DeleteMapping("/cards/{cardId}/labels/{labelId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void detachLabel(@PathVariable Long cardId, @PathVariable Long labelId) {
+        labelService.detach(cardId, labelId);
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/dto/BoardDetailResponse.java
+++ b/backend/src/main/java/com/taskmanagement/dto/BoardDetailResponse.java
@@ -1,0 +1,11 @@
+package com.taskmanagement.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record BoardDetailResponse(
+        Long id,
+        String title,
+        LocalDateTime createdAt,
+        List<ListResponse> lists
+) {}

--- a/backend/src/main/java/com/taskmanagement/dto/BoardSummaryResponse.java
+++ b/backend/src/main/java/com/taskmanagement/dto/BoardSummaryResponse.java
@@ -1,0 +1,5 @@
+package com.taskmanagement.dto;
+
+import java.time.LocalDateTime;
+
+public record BoardSummaryResponse(Long id, String title, LocalDateTime createdAt) {}

--- a/backend/src/main/java/com/taskmanagement/dto/CardResponse.java
+++ b/backend/src/main/java/com/taskmanagement/dto/CardResponse.java
@@ -1,0 +1,13 @@
+package com.taskmanagement.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record CardResponse(
+        Long id,
+        String title,
+        String description,
+        LocalDate dueDate,
+        int position,
+        List<LabelResponse> labels
+) {}

--- a/backend/src/main/java/com/taskmanagement/dto/CreateCardRequest.java
+++ b/backend/src/main/java/com/taskmanagement/dto/CreateCardRequest.java
@@ -1,0 +1,5 @@
+package com.taskmanagement.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateCardRequest(@NotBlank String title) {}

--- a/backend/src/main/java/com/taskmanagement/dto/CreateListRequest.java
+++ b/backend/src/main/java/com/taskmanagement/dto/CreateListRequest.java
@@ -1,0 +1,5 @@
+package com.taskmanagement.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateListRequest(@NotBlank String title) {}

--- a/backend/src/main/java/com/taskmanagement/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/taskmanagement/dto/ErrorResponse.java
@@ -1,0 +1,3 @@
+package com.taskmanagement.dto;
+
+public record ErrorResponse(int status, String message) {}

--- a/backend/src/main/java/com/taskmanagement/dto/LabelResponse.java
+++ b/backend/src/main/java/com/taskmanagement/dto/LabelResponse.java
@@ -1,0 +1,3 @@
+package com.taskmanagement.dto;
+
+public record LabelResponse(Long id, String name, String color) {}

--- a/backend/src/main/java/com/taskmanagement/dto/ListResponse.java
+++ b/backend/src/main/java/com/taskmanagement/dto/ListResponse.java
@@ -1,0 +1,10 @@
+package com.taskmanagement.dto;
+
+import java.util.List;
+
+public record ListResponse(
+        Long id,
+        String title,
+        int position,
+        List<CardResponse> cards
+) {}

--- a/backend/src/main/java/com/taskmanagement/dto/UpdateCardRequest.java
+++ b/backend/src/main/java/com/taskmanagement/dto/UpdateCardRequest.java
@@ -1,0 +1,11 @@
+package com.taskmanagement.dto;
+
+import java.time.LocalDate;
+
+public record UpdateCardRequest(
+        String title,
+        String description,
+        LocalDate dueDate,
+        Integer position,
+        Long listId
+) {}

--- a/backend/src/main/java/com/taskmanagement/dto/UpdateListRequest.java
+++ b/backend/src/main/java/com/taskmanagement/dto/UpdateListRequest.java
@@ -1,0 +1,3 @@
+package com.taskmanagement.dto;
+
+public record UpdateListRequest(String title, Integer position) {}

--- a/backend/src/main/java/com/taskmanagement/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/taskmanagement/exception/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.taskmanagement.exception;
+
+import com.taskmanagement.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponse handleNotFound(ResourceNotFoundException e) {
+        return new ErrorResponse(HttpStatus.NOT_FOUND.value(), e.getMessage());
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/taskmanagement/exception/GlobalExceptionHandler.java
@@ -2,9 +2,12 @@ package com.taskmanagement.exception;
 
 import com.taskmanagement.dto.ErrorResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -13,5 +16,14 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ErrorResponse handleNotFound(ResourceNotFoundException e) {
         return new ErrorResponse(HttpStatus.NOT_FOUND.value(), e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(f -> f.getField() + ": " + f.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        return new ErrorResponse(HttpStatus.BAD_REQUEST.value(), message);
     }
 }

--- a/backend/src/main/java/com/taskmanagement/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/taskmanagement/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.taskmanagement.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/initializer/DataInitializer.java
+++ b/backend/src/main/java/com/taskmanagement/initializer/DataInitializer.java
@@ -1,0 +1,98 @@
+package com.taskmanagement.initializer;
+
+import com.taskmanagement.entity.Board;
+import com.taskmanagement.entity.BoardList;
+import com.taskmanagement.entity.Card;
+import com.taskmanagement.entity.Label;
+import com.taskmanagement.repository.BoardRepository;
+import com.taskmanagement.repository.BoardListRepository;
+import com.taskmanagement.repository.CardRepository;
+import com.taskmanagement.repository.LabelRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DataInitializer {
+
+    private final BoardRepository boardRepository;
+    private final BoardListRepository listRepository;
+    private final CardRepository cardRepository;
+    private final LabelRepository labelRepository;
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional
+    public void init() {
+        if (boardRepository.count() > 0) {
+            log.info("テストデータは投入済みのためスキップします");
+            return;
+        }
+
+        log.info("テストデータを投入します...");
+
+        // ===== ラベル =====
+        Label urgent = saveLabel("🔴 緊急", "#ef4444");
+        Label medium = saveLabel("🟡 中",   "#f59e0b");
+        Label low    = saveLabel("🟢 低",   "#22c55e");
+
+        // ===== ボード =====
+        Board board = new Board();
+        board.setTitle("タスク管理ボード");
+        board = boardRepository.save(board);
+
+        // ===== リスト =====
+        BoardList todo       = saveList(board, "📋 To Do",        0);
+        BoardList inProgress = saveList(board, "🔄 In Progress",  1);
+        BoardList done       = saveList(board, "✅ Done",          2);
+
+        // ===== To Do のカード =====
+        saveCard(todo, "デザインの修正",        "トップページのバナーを修正する",   LocalDate.of(2026, 5, 10), 0, List.of(urgent));
+        saveCard(todo, "仕様書のレビュー",       "",                                 LocalDate.of(2026, 5, 8),  1, List.of(medium));
+        saveCard(todo, "APIエンドポイント設計", "",                                  null,                      2, List.of());
+
+        // ===== In Progress のカード =====
+        saveCard(inProgress, "ログイン画面の実装",  "React + Tailwind で実装",      LocalDate.of(2026, 4, 30), 0, List.of(urgent));
+        saveCard(inProgress, "データベース設計",    "ER図をもとにSQLite設定",       null,                      1, List.of(medium));
+
+        // ===== Done のカード =====
+        saveCard(done, "要件定義書の作成",   "", null, 0, List.of(low));
+        saveCard(done, "技術スタックの選定", "", null, 1, List.of(low));
+
+        log.info("テストデータの投入が完了しました");
+    }
+
+    private Label saveLabel(String name, String color) {
+        Label label = new Label();
+        label.setName(name);
+        label.setColor(color);
+        return labelRepository.save(label);
+    }
+
+    private BoardList saveList(Board board, String title, int position) {
+        BoardList list = new BoardList();
+        list.setBoard(board);
+        list.setTitle(title);
+        list.setPosition(position);
+        return listRepository.save(list);
+    }
+
+    private void saveCard(BoardList list, String title, String description,
+                          LocalDate dueDate, int position, List<Label> labels) {
+        Card card = new Card();
+        card.setList(list);
+        card.setTitle(title);
+        card.setDescription(description);
+        card.setDueDate(dueDate);
+        card.setPosition(position);
+        card.setLabels(labels);
+        cardRepository.save(card);
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/service/BoardListService.java
+++ b/backend/src/main/java/com/taskmanagement/service/BoardListService.java
@@ -1,0 +1,58 @@
+package com.taskmanagement.service;
+
+import com.taskmanagement.dto.CreateListRequest;
+import com.taskmanagement.dto.ListResponse;
+import com.taskmanagement.dto.UpdateListRequest;
+import com.taskmanagement.entity.Board;
+import com.taskmanagement.entity.BoardList;
+import com.taskmanagement.exception.ResourceNotFoundException;
+import com.taskmanagement.repository.BoardListRepository;
+import com.taskmanagement.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BoardListService {
+
+    private final BoardRepository boardRepository;
+    private final BoardListRepository listRepository;
+
+    @Transactional
+    public ListResponse create(Long boardId, CreateListRequest req) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new ResourceNotFoundException("Board not found: id=" + boardId));
+
+        int position = board.getLists().size();
+        BoardList list = new BoardList();
+        list.setBoard(board);
+        list.setTitle(req.title());
+        list.setPosition(position);
+        list = listRepository.save(list);
+
+        return new ListResponse(list.getId(), list.getTitle(), list.getPosition(), List.of());
+    }
+
+    @Transactional
+    public ListResponse update(Long id, UpdateListRequest req) {
+        BoardList list = listRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("List not found: id=" + id));
+
+        if (req.title() != null) list.setTitle(req.title());
+        if (req.position() != null) list.setPosition(req.position());
+        list = listRepository.save(list);
+
+        return new ListResponse(list.getId(), list.getTitle(), list.getPosition(), List.of());
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        if (!listRepository.existsById(id)) {
+            throw new ResourceNotFoundException("List not found: id=" + id);
+        }
+        listRepository.deleteById(id);
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/service/BoardService.java
+++ b/backend/src/main/java/com/taskmanagement/service/BoardService.java
@@ -1,0 +1,63 @@
+package com.taskmanagement.service;
+
+import com.taskmanagement.dto.*;
+import com.taskmanagement.entity.Board;
+import com.taskmanagement.entity.BoardList;
+import com.taskmanagement.entity.Card;
+import com.taskmanagement.entity.Label;
+import com.taskmanagement.exception.ResourceNotFoundException;
+import com.taskmanagement.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+    private final BoardRepository boardRepository;
+
+    @Transactional(readOnly = true)
+    public List<BoardSummaryResponse> findAll() {
+        return boardRepository.findAll().stream()
+                .map(b -> new BoardSummaryResponse(b.getId(), b.getTitle(), b.getCreatedAt()))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public BoardDetailResponse findById(Long id) {
+        Board board = boardRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Board not found: id=" + id));
+        return toDetailResponse(board);
+    }
+
+    private BoardDetailResponse toDetailResponse(Board board) {
+        List<ListResponse> lists = board.getLists().stream()
+                .map(this::toListResponse)
+                .toList();
+        return new BoardDetailResponse(board.getId(), board.getTitle(), board.getCreatedAt(), lists);
+    }
+
+    private ListResponse toListResponse(BoardList list) {
+        List<CardResponse> cards = list.getCards().stream()
+                .map(this::toCardResponse)
+                .toList();
+        return new ListResponse(list.getId(), list.getTitle(), list.getPosition(), cards);
+    }
+
+    private CardResponse toCardResponse(Card card) {
+        List<LabelResponse> labels = card.getLabels().stream()
+                .map(l -> new LabelResponse(l.getId(), l.getName(), l.getColor()))
+                .toList();
+        return new CardResponse(
+                card.getId(),
+                card.getTitle(),
+                card.getDescription(),
+                card.getDueDate(),
+                card.getPosition(),
+                labels
+        );
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/service/CardService.java
+++ b/backend/src/main/java/com/taskmanagement/service/CardService.java
@@ -1,0 +1,71 @@
+package com.taskmanagement.service;
+
+import com.taskmanagement.dto.CardResponse;
+import com.taskmanagement.dto.CreateCardRequest;
+import com.taskmanagement.dto.LabelResponse;
+import com.taskmanagement.dto.UpdateCardRequest;
+import com.taskmanagement.entity.BoardList;
+import com.taskmanagement.entity.Card;
+import com.taskmanagement.exception.ResourceNotFoundException;
+import com.taskmanagement.repository.BoardListRepository;
+import com.taskmanagement.repository.CardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CardService {
+
+    private final BoardListRepository listRepository;
+    private final CardRepository cardRepository;
+
+    @Transactional
+    public CardResponse create(Long listId, CreateCardRequest req) {
+        BoardList list = listRepository.findById(listId)
+                .orElseThrow(() -> new ResourceNotFoundException("List not found: id=" + listId));
+
+        int position = list.getCards().size();
+        Card card = new Card();
+        card.setList(list);
+        card.setTitle(req.title());
+        card.setPosition(position);
+        card = cardRepository.save(card);
+
+        return new CardResponse(card.getId(), card.getTitle(), card.getDescription(),
+                card.getDueDate(), card.getPosition(), List.of());
+    }
+
+    @Transactional
+    public CardResponse update(Long id, UpdateCardRequest req) {
+        Card card = cardRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Card not found: id=" + id));
+
+        if (req.title() != null) card.setTitle(req.title());
+        if (req.description() != null) card.setDescription(req.description());
+        if (req.dueDate() != null) card.setDueDate(req.dueDate());
+        if (req.position() != null) card.setPosition(req.position());
+        if (req.listId() != null) {
+            BoardList newList = listRepository.findById(req.listId())
+                    .orElseThrow(() -> new ResourceNotFoundException("List not found: id=" + req.listId()));
+            card.setList(newList);
+        }
+        card = cardRepository.save(card);
+
+        List<LabelResponse> labels = card.getLabels().stream()
+                .map(l -> new LabelResponse(l.getId(), l.getName(), l.getColor()))
+                .toList();
+        return new CardResponse(card.getId(), card.getTitle(), card.getDescription(),
+                card.getDueDate(), card.getPosition(), labels);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        Card card = cardRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Card not found: id=" + id));
+        card.getLabels().clear();
+        cardRepository.delete(card);
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/service/LabelService.java
+++ b/backend/src/main/java/com/taskmanagement/service/LabelService.java
@@ -1,0 +1,52 @@
+package com.taskmanagement.service;
+
+import com.taskmanagement.dto.LabelResponse;
+import com.taskmanagement.entity.Card;
+import com.taskmanagement.entity.Label;
+import com.taskmanagement.exception.ResourceNotFoundException;
+import com.taskmanagement.repository.CardRepository;
+import com.taskmanagement.repository.LabelRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LabelService {
+
+    private final LabelRepository labelRepository;
+    private final CardRepository cardRepository;
+
+    @Transactional(readOnly = true)
+    public List<LabelResponse> findAll() {
+        return labelRepository.findAll().stream()
+                .map(l -> new LabelResponse(l.getId(), l.getName(), l.getColor()))
+                .toList();
+    }
+
+    @Transactional
+    public void attach(Long cardId, Long labelId) {
+        Card card = cardRepository.findById(cardId)
+                .orElseThrow(() -> new ResourceNotFoundException("Card not found: id=" + cardId));
+        Label label = labelRepository.findById(labelId)
+                .orElseThrow(() -> new ResourceNotFoundException("Label not found: id=" + labelId));
+
+        if (!card.getLabels().contains(label)) {
+            card.getLabels().add(label);
+            cardRepository.save(card);
+        }
+    }
+
+    @Transactional
+    public void detach(Long cardId, Long labelId) {
+        Card card = cardRepository.findById(cardId)
+                .orElseThrow(() -> new ResourceNotFoundException("Card not found: id=" + cardId));
+        Label label = labelRepository.findById(labelId)
+                .orElseThrow(() -> new ResourceNotFoundException("Label not found: id=" + labelId));
+
+        card.getLabels().remove(label);
+        cardRepository.save(card);
+    }
+}


### PR DESCRIPTION
## 変更内容

`feature/issue-1-crud-api` ブランチで Board の READ API を実装しました。

### 追加エンドポイント

| メソッド | パス | 説明 |
|---|---|---|
| GET | `/api/boards` | ボード一覧取得 |
| GET | `/api/boards/{id}` | ボード詳細取得（Lists・Cards・Labels をネスト） |

### 追加ファイル

- `dto/` — レスポンス用 Record クラス 6 つ
- `exception/` — ResourceNotFoundException + GlobalExceptionHandler（404 対応）
- `service/BoardService.java` — `@Transactional(readOnly=true)` でエンティティを DTO に変換
- `controller/BoardController.java` — GET エンドポイント 2 つ
- `initializer/DataInitializer.java` — 起動時に Board / List / Card / Label のテストデータを投入

### 動作確認

- `GET /api/boards` → ボード一覧 JSON ✅
- `GET /api/boards/1` → Board + 3Lists + 7Cards + Labels のネスト JSON ✅
- `GET /api/boards/999` → `{"status":404,"message":"Board not found: id=999"}` ✅

Closes #1