### PR TITLE
[Phase 3] カードのドラッグ&ドロップ実装

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "axios": "^1.16.1",
         "react": "^19.2.6",
         "react-dom": "^19.2.6"
@@ -267,6 +270,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3166,9 +3222,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "axios": "^1.16.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"

--- a/frontend/src/components/BoardView.tsx
+++ b/frontend/src/components/BoardView.tsx
@@ -1,7 +1,15 @@
 import { useState } from 'react'
-import type { Board } from '../types'
+import {
+  DndContext,
+  closestCorners,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+} from '@dnd-kit/core'
+import type { Board, Card } from '../types'
 import ListColumn from './ListColumn'
-import { createList, deleteList, createCard, deleteCard } from '../api/boards'
+import CardItem from './CardItem'
+import { createList, deleteList, createCard, deleteCard, updateCard } from '../api/boards'
 
 type Props = {
   board: Board
@@ -11,6 +19,7 @@ type Props = {
 export default function BoardView({ board, onRefresh }: Props) {
   const [addingList, setAddingList] = useState(false)
   const [listTitle, setListTitle] = useState('')
+  const [draggingCard, setDraggingCard] = useState<Card | null>(null)
 
   const handleAddList = async () => {
     if (!listTitle.trim()) return
@@ -37,7 +46,49 @@ export default function BoardView({ board, onRefresh }: Props) {
     onRefresh()
   }
 
+  const handleDragStart = ({ active }: DragStartEvent) => {
+    const cardId = parseInt((active.id as string).replace('card-', ''))
+    for (const list of board.lists) {
+      const card = list.cards.find(c => c.id === cardId)
+      if (card) { setDraggingCard(card); return }
+    }
+  }
+
+  const handleDragEnd = async ({ active, over }: DragEndEvent) => {
+    setDraggingCard(null)
+    if (!over || active.id === over.id) return
+
+    const cardId = parseInt((active.id as string).replace('card-', ''))
+    const overId = over.id as string
+
+    // ドロップ先のリストと位置を決定
+    let destListId: number
+    let newPosition: number
+
+    if (overId.startsWith('card-')) {
+      const overCardId = parseInt(overId.replace('card-', ''))
+      const destList = board.lists.find(l => l.cards.some(c => c.id === overCardId))
+      if (!destList) return
+      destListId = destList.id
+      newPosition = destList.cards.findIndex(c => c.id === overCardId)
+    } else if (overId.startsWith('list-')) {
+      destListId = parseInt(overId.replace('list-', ''))
+      const destList = board.lists.find(l => l.id === destListId)
+      newPosition = destList?.cards.length ?? 0
+    } else {
+      return
+    }
+
+    await updateCard(cardId, { listId: destListId, position: newPosition })
+    onRefresh()
+  }
+
   return (
+    <DndContext
+      collisionDetection={closestCorners}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
     <div className="flex items-start gap-3 p-4 overflow-x-auto flex-1 min-h-0">
       {board.lists.map(list => (
         <ListColumn
@@ -90,5 +141,15 @@ export default function BoardView({ board, onRefresh }: Props) {
         )}
       </div>
     </div>
+
+    {/* ドラッグ中のカードのゴースト表示 */}
+    <DragOverlay>
+      {draggingCard && (
+        <div className="rotate-2 opacity-90 w-64">
+          <CardItem card={draggingCard} listId={0} onDelete={() => {}} />
+        </div>
+      )}
+    </DragOverlay>
+    </DndContext>
   )
 }

--- a/frontend/src/components/CardItem.tsx
+++ b/frontend/src/components/CardItem.tsx
@@ -1,7 +1,10 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import type { Card } from '../types'
 
 type Props = {
   card: Card
+  listId: number
   onDelete: (cardId: number) => void
 }
 
@@ -11,11 +14,29 @@ const LABEL_STYLE: Record<string, string> = {
   '#22c55e': 'bg-green-100 text-green-700',
 }
 
-export default function CardItem({ card, onDelete }: Props) {
+export default function CardItem({ card, listId, onDelete }: Props) {
   const isOverdue = card.dueDate && card.dueDate < new Date().toISOString().split('T')[0]
 
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: `card-${card.id}`,
+    data: { type: 'card', listId },
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+    cursor: isDragging ? 'grabbing' : 'grab',
+  }
+
   return (
-    <div className="bg-white rounded-lg p-3 shadow-sm border border-gray-200 hover:shadow-md transition-shadow">
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      className={`bg-white rounded-lg p-3 shadow-sm border border-gray-200 hover:shadow-md transition-shadow select-none ${isDragging ? 'ring-2 ring-blue-400' : ''}`}
+    >
       {/* ラベル */}
       {card.labels.length > 0 && (
         <div className="flex flex-wrap gap-1 mb-2">
@@ -34,6 +55,7 @@ export default function CardItem({ card, onDelete }: Props) {
         <span className="text-sm text-gray-800 leading-snug break-words flex-1">{card.title}</span>
         <button
           onClick={() => onDelete(card.id)}
+          onPointerDown={e => e.stopPropagation()}
           className="text-gray-300 hover:text-red-400 transition-colors flex-shrink-0 text-base leading-none"
           title="削除"
         >

--- a/frontend/src/components/ListColumn.tsx
+++ b/frontend/src/components/ListColumn.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import { useDroppable } from '@dnd-kit/core'
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import type { BoardList } from '../types'
 import CardItem from './CardItem'
 
@@ -10,6 +12,7 @@ type Props = {
 }
 
 export default function ListColumn({ list, onDeleteList, onAddCard, onDeleteCard }: Props) {
+  const { setNodeRef, isOver } = useDroppable({ id: `list-${list.id}` })
   const [adding, setAdding] = useState(false)
   const [title, setTitle] = useState('')
   const [loading, setLoading] = useState(false)
@@ -38,14 +41,22 @@ export default function ListColumn({ list, onDeleteList, onAddCard, onDeleteCard
       </div>
 
       {/* カード一覧 */}
-      <div className="flex-1 overflow-y-auto px-2 flex flex-col gap-2 pb-2">
-        {list.cards.length === 0 && (
-          <p className="text-xs text-gray-400 text-center py-3">カードがありません</p>
-        )}
-        {list.cards.map(card => (
-          <CardItem key={card.id} card={card} onDelete={onDeleteCard} />
-        ))}
-      </div>
+      <SortableContext
+        items={list.cards.map(c => `card-${c.id}`)}
+        strategy={verticalListSortingStrategy}
+      >
+        <div
+          ref={setNodeRef}
+          className={`flex-1 overflow-y-auto px-2 flex flex-col gap-2 pb-2 min-h-12 rounded-lg transition-colors ${isOver ? 'bg-blue-50' : ''}`}
+        >
+          {list.cards.length === 0 && (
+            <p className="text-xs text-gray-400 text-center py-3">カードがありません</p>
+          )}
+          {list.cards.map(card => (
+            <CardItem key={card.id} card={card} listId={list.id} onDelete={onDeleteCard} />
+          ))}
+        </div>
+      </SortableContext>
 
       {/* カード追加エリア */}
       <div className="px-2 pb-2">


### PR DESCRIPTION
## 変更内容

@dnd-kit を使用してカードのドラッグ&ドロップを実装しました。

### 実装した機能

| 機能 | 内容 |
|---|---|
| リスト内並び替え | カードをつかんで同じリスト内で上下に移動 |
| リスト間移動 | カードをつかんで別のリストにドロップ |
| 空リストへのドロップ | カードのないリストへの移動も対応 |
| ゴースト表示 | ドラッグ中は元の位置に半透明カード、カーソルにゴーストを表示 |
| DB 永続化 | ドロップ後に PATCH /api/cards/{id} で listId・position を更新 |

### 使用ライブラリ
- `@dnd-kit/core` — DndContext, DragOverlay
- `@dnd-kit/sortable` — SortableContext, useSortable
- `@dnd-kit/utilities` — CSS.Transform

Closes #3