### PR TITLE
[Maintenance] Terraform IaC コードのバージョン管理追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,12 @@ Thumbs.db
 # 環境変数（パスワード等の機密情報）
 .env
 
+# Terraform
+terraform/.terraform/
+terraform/*.tfstate
+terraform/*.tfstate.backup
+terraform/prod.tfvars
+
 # Claude Code 内部ファイル（settings.json はチーム共有のため追跡する）
 .claude/
 !.claude/settings.json

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -1,0 +1,90 @@
+# CloudFront が S3 にアクセスするための OAC
+resource "aws_cloudfront_origin_access_control" "frontend" {
+  name                              = "${var.project_name}-oac"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "main" {
+  enabled             = true
+  default_root_object = "index.html"
+  price_class         = "PriceClass_200" # 日本・アジア・米国・欧州のみ（All より安価）
+
+  # オリジン①: S3（フロントエンド）
+  origin {
+    domain_name              = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_id                = "S3-frontend"
+    origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+  }
+
+  # オリジン②: EC2（バックエンドAPI）
+  origin {
+    domain_name = aws_eip.app.public_dns
+    origin_id   = "EC2-backend"
+
+    custom_origin_config {
+      http_port              = 8080
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  # デフォルト: フロントエンド（S3）
+  default_cache_behavior {
+    target_origin_id       = "S3-frontend"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+
+    forwarded_values {
+      query_string = false
+      cookies { forward = "none" }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+  }
+
+  # /api/* はバックエンド（EC2）へ転送
+  ordered_cache_behavior {
+    path_pattern           = "/api/*"
+    target_origin_id       = "EC2-backend"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+
+    forwarded_values {
+      query_string = true
+      headers      = ["Authorization", "Content-Type", "Accept", "Origin"]
+      cookies { forward = "none" }
+    }
+
+    min_ttl     = 0
+    default_ttl = 0
+    max_ttl     = 0
+  }
+
+  # SPA 用: 404 を index.html にリダイレクト
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 0
+  }
+
+  restrictions {
+    geo_restriction { restriction_type = "none" }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  tags = {
+    Name    = "${var.project_name}-cf"
+    Project = var.project_name
+  }
+}

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,0 +1,52 @@
+# Amazon Linux 2023 の最新 AMI を自動取得
+data "aws_ami" "amazon_linux_2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+
+resource "aws_instance" "app" {
+  ami                    = data.aws_ami.amazon_linux_2023.id
+  instance_type          = var.ec2_instance_type
+  subnet_id              = aws_subnet.public.id
+  vpc_security_group_ids = [aws_security_group.ec2.id]
+  iam_instance_profile   = aws_iam_instance_profile.ec2.name
+
+  root_block_device {
+    volume_size = 30
+    volume_type = "gp3"
+  }
+
+  # 起動時に Docker・Docker Compose・SSM Agent をセットアップ
+  user_data = base64encode(templatefile("${path.module}/user_data.sh", {
+    db_username = var.db_username
+    db_password = var.db_password
+    db_name     = var.db_name
+    aws_region  = var.aws_region
+  }))
+
+  tags = {
+    Name    = "${var.project_name}-app"
+    Project = var.project_name
+  }
+}
+
+# Elastic IP（EC2 を停止・起動してもIPが変わらないように）
+resource "aws_eip" "app" {
+  instance = aws_instance.app.id
+  domain   = "vpc"
+
+  tags = {
+    Name    = "${var.project_name}-eip"
+    Project = var.project_name
+  }
+}

--- a/terraform/ec2_setup.sh
+++ b/terraform/ec2_setup.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+BUCKET="taskmanagement-frontend-237228997080"
+DB_PASSWORD="2NAZDTrkULo2GYbQBGmjCpjj"
+
+# Java 21 インストール
+dnf install -y java-21-amazon-corretto-headless
+
+# アプリディレクトリ準備
+mkdir -p /app
+cd /app
+
+# S3 から jar をダウンロード
+aws s3 cp s3://${BUCKET}/backend/app.jar /app/app.jar
+
+# PostgreSQL が起動するまで待機（最大60秒）
+for i in $(seq 1 12); do
+  if docker ps 2>/dev/null | grep -q taskmanagement-postgres; then
+    echo "PostgreSQL is running"
+    break
+  fi
+  echo "Waiting for PostgreSQL... ($i/12)"
+  sleep 5
+done
+
+# systemd サービスファイル作成
+cat > /etc/systemd/system/taskmanagement.service << UNIT
+[Unit]
+Description=Task Management Spring Boot App
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/app
+Environment=SPRING_PROFILES_ACTIVE=prod
+Environment=DB_HOST=localhost
+Environment=DB_PORT=5432
+Environment=DB_NAME=taskmanagement
+Environment=DB_USER=postgres
+Environment=DB_PASSWORD=${DB_PASSWORD}
+ExecStart=/usr/bin/java -jar /app/app.jar
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable taskmanagement
+systemctl start taskmanagement
+
+echo "=== Setup complete ==="
+systemctl status taskmanagement --no-pager

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,41 @@
+# EC2 が SSM・ECR・CloudWatch を使うための IAM ロール
+resource "aws_iam_role" "ec2" {
+  name = "${var.project_name}-ec2-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+# SSM セッションマネージャー（SSH不要のサーバー管理）
+resource "aws_iam_role_policy_attachment" "ec2_ssm" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# ECR からの Docker イメージプル
+resource "aws_iam_role_policy_attachment" "ec2_ecr" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+# S3 からの jar・スクリプト取得（読み取り専用）
+resource "aws_iam_role_policy_attachment" "ec2_s3" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+}
+
+# EC2 インスタンスプロファイル（EC2にロールを付与するためのラッパー）
+resource "aws_iam_instance_profile" "ec2" {
+  name = "${var.project_name}-ec2-profile"
+  role = aws_iam_role.ec2.name
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+}
+
+# CloudFront は us-east-1 固定
+provider "aws" {
+  alias   = "us_east_1"
+  region  = "us-east-1"
+  profile = var.aws_profile
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "cloudfront_url" {
+  description = "アプリケーションの URL（フロントエンド・API 共通）"
+  value       = "https://${aws_cloudfront_distribution.main.domain_name}"
+}
+
+output "ec2_instance_id" {
+  description = "EC2 インスタンス ID（SSM 接続時に使用）"
+  value       = aws_instance.app.id
+}
+
+output "ec2_public_ip" {
+  description = "EC2 の Elastic IP"
+  value       = aws_eip.app.public_ip
+}
+
+output "s3_bucket_name" {
+  description = "フロントエンドデプロイ先の S3 バケット名"
+  value       = aws_s3_bucket.frontend.bucket
+}
+
+output "ssm_connect_command" {
+  description = "SSM セッションマネージャーでの接続コマンド"
+  value       = "aws ssm start-session --target ${aws_instance.app.id} --profile ${var.aws_profile}"
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,0 +1,53 @@
+resource "aws_s3_bucket" "frontend" {
+  bucket = "${var.project_name}-frontend-${data.aws_caller_identity.current.account_id}"
+
+  tags = {
+    Name    = "${var.project_name}-frontend"
+    Project = var.project_name
+  }
+}
+
+# パブリックアクセスを完全ブロック（CloudFront 経由のみ許可）
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# 静的ウェブサイトホスティング設定
+resource "aws_s3_bucket_website_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  index_document { suffix = "index.html" }
+  error_document { key = "index.html" }
+}
+
+# CloudFront OAC からのアクセスのみ許可するバケットポリシー
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "AllowCloudFrontOAC"
+      Effect = "Allow"
+      Principal = {
+        Service = "cloudfront.amazonaws.com"
+      }
+      Action   = "s3:GetObject"
+      Resource = "${aws_s3_bucket.frontend.arn}/*"
+      Condition = {
+        StringEquals = {
+          "AWS:SourceArn" = aws_cloudfront_distribution.main.arn
+        }
+      }
+    }]
+  })
+
+  depends_on = [aws_cloudfront_distribution.main]
+}
+
+data "aws_caller_identity" "current" {}

--- a/terraform/security_group.tf
+++ b/terraform/security_group.tf
@@ -1,0 +1,32 @@
+# CloudFront マネージドプレフィックスリストのID（ap-northeast-1）
+data "aws_ec2_managed_prefix_list" "cloudfront" {
+  name = "com.amazonaws.global.cloudfront.origin-facing"
+}
+
+resource "aws_security_group" "ec2" {
+  name        = "${var.project_name}-ec2-sg"
+  description = "Security group for EC2 instance"
+  vpc_id      = aws_vpc.main.id
+
+  # CloudFront からの API アクセスのみ許可
+  ingress {
+    description     = "API from CloudFront"
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    prefix_list_ids = [data.aws_ec2_managed_prefix_list.cloudfront.id]
+  }
+
+  # アウトバウンドは全て許可（パッケージ取得・AWS API通信用）
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${var.project_name}-ec2-sg"
+    Project = var.project_name
+  }
+}

--- a/terraform/user_data.sh
+++ b/terraform/user_data.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+# Docker インストール
+dnf update -y
+dnf install -y docker
+systemctl enable docker
+systemctl start docker
+
+# Docker Compose インストール
+curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+
+# SSM Agent は Amazon Linux 2023 にデフォルト搭載済み
+systemctl enable amazon-ssm-agent
+systemctl start amazon-ssm-agent
+
+# アプリディレクトリ作成
+mkdir -p /app
+
+# PostgreSQL を Docker で起動
+cat <<EOF > /app/docker-compose.yml
+version: '3.8'
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: taskmanagement-postgres
+    environment:
+      POSTGRES_DB: ${db_name}
+      POSTGRES_USER: ${db_username}
+      POSTGRES_PASSWORD: ${db_password}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    restart: always
+
+volumes:
+  postgres-data:
+EOF
+
+cd /app && docker-compose up -d

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,41 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "aws_profile" {
+  description = "AWS CLI profile name"
+  type        = string
+  default     = "default"
+}
+
+variable "project_name" {
+  description = "Project name prefix for all resources"
+  type        = string
+  default     = "taskmanagement"
+}
+
+variable "db_password" {
+  description = "PostgreSQL password (used in EC2 Docker)"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_username" {
+  description = "PostgreSQL username"
+  type        = string
+  default     = "postgres"
+}
+
+variable "db_name" {
+  description = "PostgreSQL database name"
+  type        = string
+  default     = "taskmanagement"
+}
+
+variable "ec2_instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,50 @@
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name    = "${var.project_name}-vpc"
+    Project = var.project_name
+  }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "${var.aws_region}a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name    = "${var.project_name}-public-subnet"
+    Project = var.project_name
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name    = "${var.project_name}-igw"
+    Project = var.project_name
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name    = "${var.project_name}-public-rt"
+    Project = var.project_name
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}


### PR DESCRIPTION
## Summary
- AWS インフラ構築に使用した Terraform ファイル群（`.tf` 12ファイル）を追加
- `user_data.sh`（Docker + PostgreSQL 起動）・`ec2_setup.sh`（Java + Spring Boot セットアップ）を含む
- 機密情報（`prod.tfvars`・`tfstate`）は `.gitignore` で除外

## 対象リソース
- VPC / Subnet / IGW / Route Table
- EC2 (t2.micro) + EIP + IAM + Security Group
- S3 + CloudFront (OAC)

## Test plan
- [ ] `terraform plan -var-file="prod.tfvars"` でエラーが出ないこと

Closes #21